### PR TITLE
fix: reference bin/setup.sh in local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@ If you want to curate, edit, add or change content on the documentation, please 
 to [the Mage-OS DevdDocs Repository](https://github.com/mage-os/devdocs).
 
 ## Local Development
-
 The website is build with Laravel. **A database is not required**. You can run the website locally with the following
 commands:
 
 ```bash
-composer install
-npm install
+git clone git@github.com:mage-os/devdocs-website.git devdocs-website
+cd devdocs-website
+bash bin/setup.sh
+```
+
+Next, you need to compile the assets and start the server:
+
+```bash
 npm run dev
 php artisan serve
 ```
@@ -36,7 +41,7 @@ at [torchlight.dev](https://torchlight.dev/) and generate a free personal token 
 add your token to your .env file:
 
 ```ini
-TORCHLIGHT_TOKEN = your-torchlight-token
+TORCHLIGHT_TOKEN=your-torchlight-token
 ```
 
 ### Syncing Upstream Changes Into Your Fork


### PR DESCRIPTION
The current installation instructions do not mention the handy script in the `bin` folder and are thus incorrect, since the `php artisan key:generate` step is missing.