### PR TITLE
DEVDOCS-WEBSITE-19 - Fix meta tags

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -8,6 +8,10 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class DocsController extends Controller
 {
+    public const DEFAULT_META_TITLE = 'Mage-OS - Community driven eCommerce';
+    public const DEFAULT_META_DESCRIPTION = 'The Mage-OS Association is a non-profit association Formed by people within the Magento community to represent and further the interests of that community as a whole: Merchants, developers, agencies, and all of the many people supporting and supported by this ecosystem.';
+    const DEFAULT_META_KEYWORDS = 'Mage-OS, Magento 2';
+
     /**
      * The documentation repository.
      *
@@ -80,7 +84,12 @@ class DocsController extends Controller
         }
 
         $sectionPage = $page ?: 'installation-guide';
-        $content = $this->docs->get($version, $sectionPage);
+        $docPage = $this->docs->get($version, $sectionPage);
+        $content = $docPage['content'];
+        $pageCustomData = $docPage['frontendMatter'];
+        $metaDescription = $pageCustomData['description'] ?? self::DEFAULT_META_DESCRIPTION;
+        $metaKeywords = $pageCustomData['keywords'] ?? self::DEFAULT_META_KEYWORDS;
+        $communityNote = $pageCustomData['communityNote'] ?? true;
 
         if (is_null($content)) {
             $otherVersions = $this->docs->versionsContainingPage($page);
@@ -116,7 +125,7 @@ class DocsController extends Controller
         }
 
         return view('docs', [
-            'title' => count($title) ? $title->text() : null,
+            'title' => count($title) ? $title->text() : self::DEFAULT_META_TITLE,
             'index' => $this->docs->getIndex($version),
             'content' => $content,
             'currentVersion' => $version,
@@ -124,6 +133,10 @@ class DocsController extends Controller
             'currentSection' => $section,
             'canonical' => $canonical,
             'edit_link' => $this->docs->getEditUrl($version, $sectionPage),
+            'metaTitle' => count($title) ? $title->text() : self::DEFAULT_META_TITLE,
+            'metaDescription' => $metaDescription,
+            'metaKeywords' => $metaKeywords,
+            'communityNote' => $communityNote,
         ]);
     }
 

--- a/app/Markdown/GithubFlavoredMarkdownConverter.php
+++ b/app/Markdown/GithubFlavoredMarkdownConverter.php
@@ -10,6 +10,8 @@ use Torchlight\Commonmark\V2\TorchlightExtension;
 use League\CommonMark\Environment\EnvironmentInterface;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 
 /**
  * Converts GitHub Flavored Markdown to HTML.
@@ -45,6 +47,7 @@ class GithubFlavoredMarkdownConverter extends MarkdownConverter
             'normalize' => 'relative',
             'placeholder' => '[TOC]',
         ];
+
         $environment = new Environment($config);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
@@ -52,7 +55,7 @@ class GithubFlavoredMarkdownConverter extends MarkdownConverter
         $environment->addExtension(new TorchlightExtension());
         $environment->addExtension(new HeadingPermalinkExtension());
         $environment->addExtension(new TableOfContentsExtension());
-
+        $environment->addExtension(new FrontMatterExtension());
 
         parent::__construct($environment);
     }

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.0",
-        "laravel/tinker": "^2.8",
         "laravel/sanctum": "^3.2",
+        "laravel/tinker": "^2.8",
         "spatie/laravel-sitemap": "^6.0",
         "symfony/browser-kit": "^6.0",
+        "symfony/yaml": "^6.4",
         "torchlight/torchlight-commonmark": "^0.5.2",
         "torchlight/torchlight-laravel": "^0.5.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "944aa1e452852de73d13490ea26d31f2",
+    "content-hash": "a0eccfd90dd032e38cbc05fc4a979996",
     "packages": [
         {
             "name": "brick/math",
@@ -6058,6 +6058,78 @@
             "time": "2023-03-29T21:42:15+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v6.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "762ee56b2649659380e0ef4d592d807bc17b7971"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/762ee56b2649659380e0ef4d592d807bc17b7971",
+                "reference": "762ee56b2649659380e0ef4d592d807bc17b7971",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-17T12:47:12+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.6",
             "source": {
@@ -8658,5 +8730,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/resources/views/components/accessibility/main-content-wrapper.blade.php
+++ b/resources/views/components/accessibility/main-content-wrapper.blade.php
@@ -1,4 +1,5 @@
 <div id="main-content">
+    @if ($communityNote)
     <div class="gradient-box py-8 px-5 gap-3 flex flex-col mb-10">
         <p style="margin-bottom: 0!important;">
             <span class="block font-bold">📝 Community Note</span>
@@ -7,5 +8,6 @@
             discrepancies or areas that could be improved.
         </p>
     </div>
+    @endif
     {{ $slot }}
 </div>

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -274,7 +274,7 @@
                                 </blockquote>
                             @endif
 
-                            <x-accessibility.main-content-wrapper>
+                            <x-accessibility.main-content-wrapper :communityNote="$communityNote">
                                 {!! $content !!}
                             </x-accessibility.main-content-wrapper>
                         </section>

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -11,21 +11,22 @@
     @endif
 
     <!-- Primary Meta Tags -->
-    <meta name="title" content="Mage-OS - Community driven eCommerce">
-    <meta name="description" content="The Mage-OS Association is a non-profit association Formed by people within the Magento community to represent and further the interests of that community as a whole: Merchants, developers, agencies, and all of the many people supporting and supported by this ecosystem.">
+    <meta name="title" content="{{ $metaTitle }}">
+    <meta name="description" content="{{ $metaDescription }}">
+    <meta name="keywords" content="{{ $metaKeywords }}">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://mage-os.org/">
-    <meta property="og:title" content="Mage-OS - Community driven eCommerce">
-    <meta property="og:description" content="The Mage-OS Association is a non-profit association Formed by people within the Magento community to represent and further the interests of that community as a whole: Merchants, developers, agencies, and all of the many people supporting and supported by this ecosystem.">
+    <meta property="og:url" content="{{ $canonical ? url($canonical) : 'https://mage-os.org/' }}">
+    <meta property="og:title" content="{{ $metaTitle }}">
+    <meta property="og:description" content="{{ $metaDescription }}">
     <meta property="og:image" content="https://mage-os.org/wp-content/uploads/2023/05/page-icon.png">
 
-    <!-- Twitter -->
+    <!-- Twitter / X -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://mage-os.org/">
-    <meta property="twitter:title" content="Mage-OS - Community driven eCommerce">
-    <meta property="twitter:description" content="The Mage-OS Association is a non-profit association Formed by people within the Magento community to represent and further the interests of that community as a whole: Merchants, developers, agencies, and all of the many people supporting and supported by this ecosystem.">
+    <meta property="og:url" content="{{ $canonical ? url($canonical) : 'https://mage-os.org/' }}">
+    <meta property="og:title" content="{{ $metaTitle }}">
+    <meta property="twitter:description" content="{{ $metaDescription }}">
     <meta property="twitter:image" content="https://mage-os.org/wp-content/uploads/2023/05/page-icon.png">
 
     <!-- Favicon -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,11 @@ Route::get('team', function () {
                 'twitter_username' => 'damienwebdev',
                 'location' => 'Richmond, VA',
             ]
-        ]
+        ],
+        'title' => 'Team',
+        'metaTitle' => DocsController::DEFAULT_META_TITLE,
+        'metaDescription' => DocsController::DEFAULT_META_DESCRIPTION,
+        'metaKeywords' => DocsController::DEFAULT_META_KEYWORDS,
+        'canonical' => 'team'
     ]);
 })->name('team');


### PR DESCRIPTION
I implemented this feature for the devdocs website:

- Md document files can have custom descriptions and keywords.
- Hide of community note per page.
- Default meta title, meta description, and keywords.
- Title, description, and canonical URL for Facebook / X.
- Title, meta title, meta description, meta keywords and canonical URL for team page.

To add custom meta descriptions, meta keywords, and hide community note the .md file should have this section on top of the file. For example for `installation-guide.md`:
```
---
description: Installation guide for Mage-OS, how to install it on server or local.
keywords: mage-os,magento 2,install, setup
communityNote: false
---
```
by default, a community note will be shown.

![DEVDOCS-WEBSITE-19](https://github.com/user-attachments/assets/be4bc80f-02e1-4b45-9e34-9c763f9597be)
