### PR TITLE
devdocs-website-6 Add Contributor Highlights in the docs

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -90,6 +90,8 @@ class DocsController extends Controller
         $metaDescription = $pageCustomData['description'] ?? self::DEFAULT_META_DESCRIPTION;
         $metaKeywords = $pageCustomData['keywords'] ?? self::DEFAULT_META_KEYWORDS;
         $communityNote = $pageCustomData['communityNote'] ?? true;
+        $contributors = $pageCustomData['contributors'] ?? false;
+        $contributorsData = explode(',', $contributors);
 
         if (is_null($content)) {
             $otherVersions = $this->docs->versionsContainingPage($page);
@@ -137,6 +139,7 @@ class DocsController extends Controller
             'metaDescription' => $metaDescription,
             'metaKeywords' => $metaKeywords,
             'communityNote' => $communityNote,
+            'contributors' => $contributorsData,
         ]);
     }
 

--- a/resources/views/components/accessibility/contributors.blade.php
+++ b/resources/views/components/accessibility/contributors.blade.php
@@ -1,0 +1,26 @@
+@if ($contributors)
+    <div>
+        <div>
+            <h3>Want to see who contributed this for you?</h3>
+        </div>
+        <div style="margin-bottom: 10px;">A special thanks goes to our contributors:</div>
+        <div>
+            <div>
+                @foreach($contributors as $contributor)
+                    <div style="display: inline-flex; align-items: center; gap: 10px; margin-right: 10px;">
+                        <figure style="max-width: 60px; margin: 0;">
+                            <img
+                                src="https://github.com/{{$contributor}}.png"
+                                alt="{{$contributor}}"
+                                width="60"
+                                height="60"
+                                style="border-radius: 50%; display: block;"
+                            >
+                        </figure>
+                        <a href="https://github.com/{{$contributor}}" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: inherit;">{{$contributor}}</a>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -277,6 +277,9 @@
                             <x-accessibility.main-content-wrapper :communityNote="$communityNote">
                                 {!! $content !!}
                             </x-accessibility.main-content-wrapper>
+                            <x-accessibility.contributors :contributors="$contributors">
+
+                            </x-accessibility.contributors>
                         </section>
                     </section>
                 </div>


### PR DESCRIPTION
I added contributors section to the bottom of the docs page

![contributors](https://github.com/user-attachments/assets/cdf09111-2ae9-4ab9-9c4c-6836ad85a184)

The contributors are added to page custom data section - for example for installation guide we will have something like that:
```
---
description: Learn how to install Mage-OS with this comprehensive guide. Includes step-by-step instructions, prerequisites, system requirements, and troubleshooting tips for setting up your eCommerce platform.
keywords: Mage-OS installation, Mage-OS setup, Mage-OS prerequisites, eCommerce platform, system requirements, Mage-OS installation guide, Mage-OS documentation, install Mage-OS, Mage-OS troubleshooting.
communityNote: false
contributors: nikolalardev,fballiano,vinai,DavidLambauer,laurali123
---
```
And the username is link to their profile in github.